### PR TITLE
chore: rename rust module to `_endec` for IDE compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-name = "endec"
+name = "_endec"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ requires-python = ">=3.8"
 Repository = "https://github.com/fluxth/endec"
 
 [tool.maturin]
+module-name = "endec._endec"
 python-source = "python"
 features = ["pyo3/extension-module"]
 

--- a/python/endec/__init__.py
+++ b/python/endec/__init__.py
@@ -1,4 +1,4 @@
-from .endec import encode, decode
+from ._endec import encode, decode
 
-__doc__ = endec.__doc__
+__doc__ = _endec.__doc__
 __all__ = ["encode", "decode"]

--- a/python/endec/exceptions.py
+++ b/python/endec/exceptions.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import TYPE_CHECKING, Optional
+    from typing import Optional
 
 
 class DecodeError(UnicodeError):

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod exceptions {
 use pyo3::prelude::*;
 
 #[pymodule]
-fn endec(_py: Python, module: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _endec(_py: Python, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(encode::encode, module)?)?;
     module.add_function(wrap_pyfunction!(decode::decode, module)?)?;
     Ok(())


### PR DESCRIPTION
https://www.maturin.rs/project_layout#import-rust-as-a-submodule-of-your-project

pycharm seems to dislike native module that has the same name of python module