### PR TITLE
fix(ci): drop python 3.8 wheel builds for windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ permissions:
 env:
   UNIX_PYTHON_BUILD_VERSIONS: 3.13 3.12 3.11 3.10 3.9 3.8 pypy3.10 pypy3.9
   # PyPy is not supported on 32-bit Windows
-  WINDOWS_PYTHON_BUILD_VERSIONS: 3.13 3.12 3.11 3.10 3.9 3.8
+  WINDOWS_PYTHON_BUILD_VERSIONS: 3.13 3.12 3.11 3.10 3.9
   # renovate: datasource=github-releases depName=PyO3/maturin
   MATURIN_VERSION: v1.8.7
 


### PR DESCRIPTION
GHA runner no longer supports this on Windows.